### PR TITLE
Fix a typo

### DIFF
--- a/src/examples/compiler_internals/TODO.txt
+++ b/src/examples/compiler_internals/TODO.txt
@@ -5,5 +5,5 @@
 - investigate further the compiler barrier. The volatile part vs the memory
 	part. show when each is neccessary.
 - is there a user space version of cpu_relax of kernel space ?!?
-- do more examples like the usused result one to show how to use the compiler
+- do more examples like the unused result one to show how to use the compiler
 	to guard against problems (checking of constant, more).

--- a/src/examples/compiler_internals/unused_result_warning.cc
+++ b/src/examples/compiler_internals/unused_result_warning.cc
@@ -60,7 +60,7 @@ int main(int argc, char** argv, char** envp) {
 	add(5, 6);
 	#pragma GCC diagnostic pop
 	// another way to ignore the requirement to use the result is to put it in a variable
-	// but to mark the variable as "usused"...
+	// but to mark the variable as "unused"...
 	int c __attribute__((unused))=add(a, b);
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
I think it should be "unused" instead of "usused", unless I am wrong. :smile: 
